### PR TITLE
Add MCP server tests and Jest configuration

### DIFF
--- a/scraping-mcp-agent/jest.config.js
+++ b/scraping-mcp-agent/jest.config.js
@@ -1,11 +1,11 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  roots: ['<rootDir>/scraping-mcp-agent/src', '<rootDir>/tests'],
+  roots: ['<rootDir>/src', '<rootDir>/../tests'],
   testMatch: ['**/?(*.)+(spec|test).ts'],
   transform: {
     '^.+\\.ts$': 'ts-jest'
   },
-  setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
+  setupFilesAfterEnv: ['<rootDir>/../tests/setup.ts'],
   testTimeout: 30000,
 };

--- a/tests/mcp-server-test.ts
+++ b/tests/mcp-server-test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect, beforeAll, afterAll } from '@jest/globals';
+import { createScrapingMCPServer } from '../scraping-mcp-agent/src/mcp/mcp-server.js';
+
+/**
+ * Basic tests for the Scraping MCP Server
+ */
+
+describe('ScrapingMCPServer', () => {
+  let server: any;
+
+  beforeAll(async () => {
+    server = createScrapingMCPServer({
+      enableLogging: false,
+      enableMetrics: false,
+      enableRateLimit: false,
+    });
+    if (server.start) {
+      await server.start();
+    }
+  });
+
+  afterAll(async () => {
+    if (server) {
+      await server['server']?.close?.();
+      await server['toolsHandler']?.dispose?.();
+    }
+  });
+
+  test('system_status tool responds with health information', async () => {
+    const toolsHandler = server['toolsHandler'];
+    const response = await toolsHandler.systemStatus({
+      component: 'all',
+      includeMetrics: false,
+      includeHealth: true,
+    });
+
+    expect(response.success).toBe(true);
+    expect(response.metadata.toolName).toBe('system_status');
+    expect(response.data).toHaveProperty('uptime');
+    expect(response.data).toHaveProperty('timestamp');
+  });
+});


### PR DESCRIPTION
## Summary
- fix Jest configuration
- add project-specific Jest config
- add tests for ScrapingMCPServer

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687815b1dac08325972adf8b71a151f4