### PR TITLE
Use env vars for login details

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,7 @@ MCP_SERVER_HOST=localhost
 # === OPTIONAL APIs ===
 # PROXY_MESH_API_KEY=your_proxy_api_key
 # CAPTCHA_SOLVER_API_KEY=your_captcha_api_key
+
+# === LOGIN CREDENTIALS ===
+# LOGIN_EMAIL=your_email@example.com
+# LOGIN_PASSWORD=your_password

--- a/scraping-mcp-agent/debug-example.ts
+++ b/scraping-mcp-agent/debug-example.ts
@@ -165,11 +165,11 @@ async function debugLogin() {
       
       // Llenar campos
       logger.info('Llenando campo email...');
-      await emailField.fill('fmonfasani@gmail.com');
+      await emailField.fill(process.env.LOGIN_EMAIL || '');
       await page.waitForTimeout(1000);
       
       logger.info('Llenando campo password...');
-      await passwordField.fill('$Karaoke27570');
+      await passwordField.fill(process.env.LOGIN_PASSWORD || '');
       await page.waitForTimeout(1000);
       
       // Buscar botón submit

--- a/scraping-mcp-agent/examples/login-scraper.ts
+++ b/scraping-mcp-agent/examples/login-scraper.ts
@@ -309,8 +309,8 @@ async function scrapeBullMarketBrokers() {
     
     // Configuración de login
     const loginConfig: LoginConfig = {
-      email: 'fmonfasani@gmail.com',
-      password: '$Karaoke27570',
+      email: process.env.LOGIN_EMAIL || '',
+      password: process.env.LOGIN_PASSWORD || '',
       loginUrl: 'https://bullmarketbrokers.com/Security/SignIn'
     };
     

--- a/scraping-mcp-agent/focused-scraper.mjs
+++ b/scraping-mcp-agent/focused-scraper.mjs
@@ -55,8 +55,8 @@ async function scrapeFocusedData() {
     console.log('🔐 Realizando login...');
     await page.goto('https://bullmarketbrokers.com/Security/SignIn');
     
-    await page.fill('input[type="email"]', 'fmonfasani@gmail.com');
-    await page.fill('input[type="password"]', '$Karaoke27570');
+    await page.fill('input[type="email"]', process.env.LOGIN_EMAIL || '');
+    await page.fill('input[type="password"]', process.env.LOGIN_PASSWORD || '');
     await page.click('#submitButton');
     
     await page.waitForURL('**/Dashboard', { timeout: 15000 });


### PR DESCRIPTION
## Summary
- load login credentials from env vars in example scripts
- document LOGIN_EMAIL and LOGIN_PASSWORD in `.env.example`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687815b1ddb883258c05cb9de47693a2